### PR TITLE
Libretro: clean also alternate libretro core name

### DIFF
--- a/Libretro/Makefile
+++ b/Libretro/Makefile
@@ -322,7 +322,7 @@ endif
 	$(CXX) $(CXXFLAGS) $(fpic) -c $< $(OBJOUT)$@
 
 clean:
-	rm -f $(OBJECTS) $(TARGET)
+	rm -f $(OBJECTS) $(TARGET) $(ALTTARGET)
 
 .PHONY: clean
 


### PR DESCRIPTION
- mesen-s_libretro.so and also _mesens_libretro.so_ should be cleaned.