### PR TITLE
Improve compatibility with BSD family operating systems

### DIFF
--- a/Utilities/CRC32.cpp
+++ b/Utilities/CRC32.cpp
@@ -23,6 +23,8 @@ extern const uint32_t Crc32Lookup[MaxSlice][256];
 	// defines __BYTE_ORDER as __LITTLE_ENDIAN or __BIG_ENDIAN
 #if defined(__APPLE__) || defined(HAVE_LIBNX)
 #include <machine/endian.h>
+#elif defined (__FreeBSD__) || defined(__DragonFly__)
+#include <sys/endian.h>
 #else
 #include <endian.h>
 #endif

--- a/Utilities/Scale2x/scalebit.cpp
+++ b/Utilities/Scale2x/scalebit.cpp
@@ -39,7 +39,7 @@
 #include <assert.h>
 #include <stdlib.h>
 
-#if !(defined(__MACH__) || defined(__FreeBSD__))
+#if !(defined(__MACH__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__DragonFly__))
 #include <malloc.h>
 #endif
 


### PR DESCRIPTION
This improves the emulator core's compatibility with the BSD family of operating systems. NetBSD required no changes.